### PR TITLE
Add boundary wall distance

### DIFF
--- a/Fluid.py
+++ b/Fluid.py
@@ -5,7 +5,7 @@ from typing import List
 class Fluid(Simulation):
     _velocity : Vec2
     _density  : float
-    _boundary : Boundary #List[BoundaryFunction]
+    _boundary : Boundary
 
     def __init__(self, v: Vec2, d: float, boundary: Boundary = None):
         self._velocity = v

--- a/Fluid.py
+++ b/Fluid.py
@@ -1,6 +1,5 @@
 from Vec import Vec2
 from Simulation import Simulation, Boundary
-from typing import List
 
 class Fluid(Simulation):
     _velocity : Vec2

--- a/Fluid.py
+++ b/Fluid.py
@@ -1,16 +1,16 @@
 from Vec import Vec2
-from Simulation import Simulation, BoundaryFunction
+from Simulation import Simulation, Boundary
 from typing import List
 
 class Fluid(Simulation):
     _velocity : Vec2
     _density  : float
-    _boundary : List[BoundaryFunction]
+    _boundary : Boundary #List[BoundaryFunction]
 
-    def __init__(self, v: Vec2, d: float, boundary_funcs: List[BoundaryFunction] = None):
+    def __init__(self, v: Vec2, d: float, boundary: Boundary = None):
         self._velocity = v
         self._density  = d
-        self._boundary = boundary_funcs
+        self._boundary = boundary
 
     def update(self, dt):
         pass

--- a/FluidSimulation.py
+++ b/FluidSimulation.py
@@ -1,6 +1,6 @@
-from Simulation import Simulation, BoundaryFunction
-from Particle import Particle
+from Simulation import Simulation, Boundary, BoundaryFunction
 from Fluid import Fluid
+from Particle import Particle
 from Vec import Vec2
 from typing import List
 from math import pi, tan
@@ -23,7 +23,7 @@ class ParticleInFluidSimulation(Simulation):
     _elapsed_time  : float    = 0
     _sec_per_tick  : int      = None
 
-    def create_boundary_funcs() -> List[BoundaryFunction]:
+    def create_boundary() -> Boundary:
         cotan = lambda theta : 1.0/tan(theta)
         pi_2  = 2*pi
         input_range = (15.5568, 176.891)
@@ -40,13 +40,13 @@ class ParticleInFluidSimulation(Simulation):
         d_x = lambda theta: (5*(pi - theta) * cotan(theta))/pi_2
         d_y = lambda theta: (5*(pi - theta))/pi_2
 
-        return [BoundaryFunction(a_x, a_y, input_range),
-                BoundaryFunction(b_x, b_y, input_range),
-                BoundaryFunction(c_x, c_y, input_range),
-                BoundaryFunction(d_x, d_y, input_range)]
+        return Boundary([BoundaryFunction(a_x, a_y, input_range),
+                         BoundaryFunction(b_x, b_y, input_range),
+                         BoundaryFunction(c_x, c_y, input_range),
+                         BoundaryFunction(d_x, d_y, input_range)])
 
     def __init__(self, fluid_v: Vec2, fluid_d: float):
-        self._fluid = Fluid(fluid_v, fluid_d, ParticleInFluidSimulation.create_boundary_funcs())
+        self._fluid = Fluid(fluid_v, fluid_d, ParticleInFluidSimulation.create_boundary())
         self._elapsed_time = time()
 
     '''

--- a/Simulation.py
+++ b/Simulation.py
@@ -34,3 +34,16 @@ class BoundaryFunction:
             points_y.append(self._y_func(deg2rad(start)))
             start += granularity
         return (points_x, points_y)
+
+class Boundary:
+    _funcs : List[BoundaryFunction]
+
+    def __init__(self, funcs: List[BoundaryFunction]):
+        self._funcs = funcs
+
+    def plot(self, i: int, granularity: float = 0.01) -> Tuple[List[float]]:
+        assert i < len(self._funcs)
+        return self._funcs[i].plot(granularity)
+
+    def calc_wall_distance(x: float) -> float:
+        return 0.0

--- a/tests/BoundaryTest.py
+++ b/tests/BoundaryTest.py
@@ -1,5 +1,4 @@
 import matplotlib.pyplot as plt
-from math import pi, tan
 from FluidSimulation import ParticleInFluidSimulation
 
 def plot_boundary_funcs():

--- a/tests/BoundaryTest.py
+++ b/tests/BoundaryTest.py
@@ -3,11 +3,11 @@ from math import pi, tan
 from FluidSimulation import ParticleInFluidSimulation
 
 def plot_boundary_funcs():
-    boundary_funcs = ParticleInFluidSimulation.create_boundary_funcs()
+    boundary = ParticleInFluidSimulation.create_boundary()
     markers = ['r+', 'b+', 'y+', 'y+']
 
     for i in range(4):
-        points_x, points_y = boundary_funcs[i].plot(granularity=0.01)
+        points_x, points_y = boundary.plot(i, granularity=0.01)
         plt.plot(points_x, points_y, markers[i], markersize=3)
 
     plt.show()


### PR DESCRIPTION
This PR refactors the boundary condition class to include a function to calculate wall distance. In theory, this distance is just a function of the length of the pipe, where at the inlet/outlet split, there may be two distances that must be tie-broken.

Tests: Test plotting the boundary works as expected